### PR TITLE
CN-Consult/2.3.5-remove-optionality-from-startime-when-creating-an-incident

### DIFF
--- a/resources/views/dashboard/incidents/add.blade.php
+++ b/resources/views/dashboard/incidents/add.blade.php
@@ -104,8 +104,8 @@
                             </div>
                         </div>
                         <div class="form-group">
-                            <label>{{ trans('forms.incidents.incident_time') }}</label> <small class="text-muted">{{ trans('forms.optional') }}</small>
-                            <input type="text" name="created_at" class="form-control" rel="datepicker-any">
+                            <label>{{ trans('forms.incidents.incident_time') }}</label>
+                            <input type="text" name="created_at" class="form-control" rel="datepicker-any" required>
                         </div>
                         <input type="hidden" name="notify" value="0">
                         @if(subscribers_enabled())


### PR DESCRIPTION
Removed the small note that said "*optional"
![image](https://user-images.githubusercontent.com/13750648/44094162-b8430bc6-9fd5-11e8-9396-cf4c1454d1a0.png)
###### The picture above is from test server. Subscriptions are activated there
![image](https://user-images.githubusercontent.com/13750648/44094138-a766aa2e-9fd5-11e8-8daa-0edb5125ce4f.png)


Wenn i click on "Submit Incident" when i have an empty Starttime field, no incident is submitted and the datepicker automatically pops up.
![image](https://user-images.githubusercontent.com/13750648/44094467-87b1085e-9fd6-11e8-99a8-df2fb96b6f15.png)
